### PR TITLE
Import of tmodel fails

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,9 @@ install_requires =
     numpy
     scipy
     pandas
-    equilibrator-api
+    equilibrator-api==0.3.2b7
+    component-contribution==0.3.2
+
 python_requires = >=3.6
 tests_require =
     tox


### PR DESCRIPTION
Fixes #13 setting the equilibrator-api and component_contribution dependencies to 0.3.2