### PR TITLE
[FEAT] allow metabolites to be ignored

### DIFF
--- a/src/multitfa/core/compound.py
+++ b/src/multitfa/core/compound.py
@@ -28,9 +28,11 @@ class Thermo_met(Metabolite):
         self,
         metabolite,
         updated_model=None,
+        ignore=False,
     ):
         self._model = updated_model
         self._reaction = set()
+        self.is_ignore = ignore
         do_not_copy_by_ref = {"_reaction", "_model"}
         for attr, value in iteritems(metabolite.__dict__):
             if attr not in do_not_copy_by_ref:
@@ -244,7 +246,7 @@ class Thermo_met(Metabolite):
         Boolean
             True if component decomposition vector is zeros, False otherwise.
         """
-        if self.is_proton:
+        if self.is_proton or self.is_ignore:
             return False
         elif ~self.compound_vector.any():
             return True


### PR DESCRIPTION
This is to allow models with pseudometabolites which do not participate in thermodymanic computations, like enzymes in enzyme-constraint models. Otherwise, the reaction with those pseudometabolites would be lumped without the need to do so.

* [ ] fix #(issue number)
* [ ] description of feature/fix
Add a `is_ignore` attribute for `Thermo_met` that works as `is_proton`, making the metabolite not excluded; and thus not excluding its corresponding reactions.

* [ ] tests added/passed
* [ ] add an entry to the [next release](../CHANGELOG.rst)
